### PR TITLE
Fix v3 model training bugs (SR mismatch & weight norm)

### DIFF
--- a/infer/lib/infer_pack/bigvgan.py
+++ b/infer/lib/infer_pack/bigvgan.py
@@ -134,7 +134,8 @@ class BigVGANNSFGenerator(nn.Module):
         return int(getattr(self.bigvgan.h, "sampling_rate"))
 
     def remove_weight_norm(self) -> None:
-        return None
+        # type: ignore[operator]
+        self.bigvgan.remove_weight_norm()
 
     def forward(
         self,

--- a/infer/lib/train/data_utils.py
+++ b/infer/lib/train/data_utils.py
@@ -7,6 +7,7 @@ logger = logging.getLogger(__name__)
 import numpy as np
 import torch
 import torch.utils.data
+import torchaudio
 import safetensors.torch
 from typing import Iterator
 
@@ -115,10 +116,8 @@ class TextAudioLoaderMultiNSFsid(torch.utils.data.Dataset):
     def get_audio(self, filename: Path) -> tuple[torch.Tensor, torch.Tensor]:
         audio, sampling_rate = load_wav_to_torch(filename)
         if sampling_rate != self.sampling_rate:
-            raise ValueError(
-                "{} SR doesn't match target {} SR".format(
-                    sampling_rate, self.sampling_rate
-                )
+            audio = torchaudio.functional.resample(
+                audio, sampling_rate, self.sampling_rate
             )
         audio_norm = audio
         #        audio_norm = audio / self.max_wav_value

--- a/test_audio.py
+++ b/test_audio.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+from infer.lib.audio import load_audio
+print("load_audio loaded")

--- a/test_torchaudio.py
+++ b/test_torchaudio.py
@@ -1,0 +1,9 @@
+import torch
+import torchaudio
+
+# creating a test array of random numbers
+sr = 48000
+audio = torch.rand(1, 48000)
+# try to resample from 48000 to 44100
+resampled = torchaudio.functional.resample(audio, sr, 44100)
+print(resampled.shape)

--- a/test_torchaudio_1d.py
+++ b/test_torchaudio_1d.py
@@ -1,0 +1,9 @@
+import torch
+import torchaudio
+
+# creating a test array of random numbers (1D, matching data returned by `load_wav_to_torch` as returned by `read` from scipy)
+sr = 48000
+audio = torch.rand(48000)
+# try to resample from 48000 to 44100
+resampled = torchaudio.functional.resample(audio, sr, 44100)
+print(resampled.shape)


### PR DESCRIPTION
This PR fixes two issues preventing the v3 model from training correctly:

1. **Sampling rate mismatch:** The dataloader `get_audio` method threw a `ValueError` when the sample rate of the input audio didn't strictly match the config target (44100 Hz for v3). This is now fixed by using `torchaudio.functional.resample` to dynamically resample mismatching audio back to the target SR on the fly.
2. **BigVGAN weight norm bug:** The `BigVGANNSFGenerator` wrapper had a dummy `remove_weight_norm` method that just returned `None`. This prevented the `weight_norm` parameterizations from being properly removed, causing `load_state_dict` to fail when initializing from a checkpoint. It has been updated to call `self.bigvgan.remove_weight_norm()`.

---
*PR created automatically by Jules for task [60345257989446301](https://jules.google.com/task/60345257989446301) started by @yamada-sexta*